### PR TITLE
Chore/uncompiled tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,13 +17,13 @@ module.exports = function(grunt) {
           "src": ["**/*.js"],
           "dest": "js/dist/es5/",
           "ext": ".js"
-        },
-        {
-          "expand": true,
-          "cwd": "spec/js/src/",
-          "src": ["**/*.js"],
-          "dest": "spec/js/dist/",
-          "ext": ".js"
+        // },
+        // {
+        //   "expand": true,
+        //   "cwd": "spec/js/src/",
+        //   "src": ["**/*.js"],
+        //   "dest": "spec/js/",
+        //   "ext": ".js"
         }]
       }
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ x-volumes: &default-volumes
   volumes:
     - ./js:/app/js
     - ./spec:/app/spec
-    # - ./Gruntfile.js:/app/Gruntfile.js
-    # - ./package.json:/app/package.json
-    # - ./testem.json:/app/testem.json
+    - ./Gruntfile.js:/app/Gruntfile.js
+    - ./package.json:/app/package.json
+    - ./testem.json:/app/testem.json
 
 services:
   deploy_s3_production:
@@ -32,4 +32,6 @@ services:
       shm_size: 1G
     image: nyulibraries/alephjs
     command: ["yarn", "run", "test"]
-    <<: *default-volumes
+    volumes:
+      - ./js/dist:/app/js/dist
+    # <<: *default-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ x-volumes: &default-volumes
   volumes:
     - ./js:/app/js
     - ./spec:/app/spec
-    - ./Gruntfile.js:/app/Gruntfile.js
-    - ./package.json:/app/package.json
-    - ./testem.json:/app/testem.json
+    # - ./Gruntfile.js:/app/Gruntfile.js
+    # - ./package.json:/app/package.json
+    # - ./testem.json:/app/testem.json
 
 services:
   deploy_s3_production:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 version: "3.7"
+x-volumes: &default-volumes
+  volumes:
+    - ./js:/app/js
+    - ./spec:/app/spec
+    - ./Gruntfile.js:/app/Gruntfile.js
+    - ./package.json:/app/package.json
+    - ./testem.json:/app/testem.json
+
 services:
   deploy_s3_production:
     image: mesosphere/aws-cli
@@ -23,6 +31,5 @@ services:
       context: .
       shm_size: 1G
     image: nyulibraries/alephjs
-    volumes:
-      - ./js/dist:/app/js/dist
     command: ["yarn", "run", "test"]
+    <<: *default-volumes

--- a/spec/js/fixtures/holdings.mustache
+++ b/spec/js/fixtures/holdings.mustache
@@ -13,10 +13,10 @@
     {{#serve_files}}
         <script src="{{src}}"></script>
     {{/serve_files}}
-    <script src="spec/js/dist/format_holdings_spec.js"></script>
-    <script src="spec/js/dist/broken_link_spec.js"></script>
-    <script src="spec/js/dist/holding_spec.js"></script>
-    <script src="spec/js/dist/modal_dialog_spec.js"></script>
+    <script src="spec/js/src/format_holdings_spec.js"></script>
+    <script src="spec/js/src/broken_link_spec.js"></script>
+    <script src="spec/js/src/holding_spec.js"></script>
+    <script src="spec/js/src/modal_dialog_spec.js"></script>
 </head>
 
 <body id="holdings" class="items">

--- a/spec/js/fixtures/ill.mustache
+++ b/spec/js/fixtures/ill.mustache
@@ -13,7 +13,7 @@
     {{#serve_files}}
     <script src="{{src}}"></script>
     {{/serve_files}}
-    <script src="spec/js/dist/ill_spec.js"></script>
+    <script src="spec/js/src/ill_spec.js"></script>
     <script type="text/javascript">
       var doc_library = "$0100";
       var doc_number = "$0200";

--- a/spec/js/fixtures/library_account.mustache
+++ b/spec/js/fixtures/library_account.mustache
@@ -13,7 +13,7 @@
     {{#serve_files}}
         <script src="{{src}}"></script>
     {{/serve_files}}
-    <script src="spec/js/dist/library_account_spec.js"></script>
+    <script src="spec/js/src/library_account_spec.js"></script>
 </head>
 
 <body id="pindex" class="activities">

--- a/spec/js/fixtures/multi_volume_journal.mustache
+++ b/spec/js/fixtures/multi_volume_journal.mustache
@@ -12,7 +12,7 @@
 {{#serve_files}}
 <script src="{{src}}"></script>
 {{/serve_files}}
-<script src="spec/js/dist/format_holdings_spec.js"></script>
+<script src="spec/js/src/format_holdings_spec.js"></script>
 </head>
 
 <body id="holdings" class="items">

--- a/spec/js/fixtures/pds_login.mustache
+++ b/spec/js/fixtures/pds_login.mustache
@@ -12,8 +12,8 @@
 {{#serve_files}}
 <script src="{{src}}"></script>
 {{/serve_files}}
-<script src="spec/js/dist/cookies_spec.js"></script>
-<script src="spec/js/dist/pds_login_spec.js"></script>
+<script src="spec/js/src/cookies_spec.js"></script>
+<script src="spec/js/src/pds_login_spec.js"></script>
 </head>
 <body>
   <body>

--- a/spec/js/fixtures/search.mustache
+++ b/spec/js/fixtures/search.mustache
@@ -13,7 +13,7 @@
     {{#serve_files}}
         <script src="{{src}}"></script>
     {{/serve_files}}
-    <script src="spec/js/dist/search_spec.js"></script>
+    <script src="spec/js/src/search_spec.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
@laurxnemeth This should run the tests without transpiling them to ES5 first. So you could keep the Grunt running side by side with the webpack.